### PR TITLE
Bug when using the multiple option

### DIFF
--- a/app/components/select-2.js
+++ b/app/components/select-2.js
@@ -145,7 +145,7 @@ var Select2Component = Ember.Component.extend({
           var item = content[i];
           var matchIndex = values.indexOf("" + get(item, optionValuePath));
           if (matchIndex !== -1) {
-            filteredContent[matchIndex] = item;
+            filteredContent.push(item);
             // remove the found key from values array
             values.removeAt(matchIndex);
             unmatchedValues--;


### PR DESCRIPTION
Today I wanted to implement select-2 in combination with Ember. After googling, I found this project. But when I was using the code, something went wrong. Some items seems all of a sudden just to vanish.

So I started to debug the code. Problem is the following:
Using the matchIndex as key does not work (line 148), as at line 150 the value is deleted. By deleting the current value, all the remaining values will go 'one index lower'. 

Next time you enter the loop, the following value has the same index (that is 0) as the previous value. In the end all the items are gone, except the latest. >> Fix is simple, just use the `push-function`.
