### PR TITLE
Observe changes to value whit multiple selection

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -331,6 +331,7 @@ var Select2Component = Ember.Component.extend({
     this.addObserver('content.@each.' + optionLabelPath, this.valueChanged);
     this.addObserver('content.@each.' + optionDescriptionPath, this.valueChanged);
     this.addObserver('value', this.valueChanged);
+    this.addObserver('value.[]', this.valueChanged);
 
     // trigger initial data sync to set select2 to the external "value"
     this.valueChanged();


### PR DESCRIPTION
When multi is set (to true) the value property is an Array. In order to
let the value of the component be set by "the other side" of the value
binding, changes on the Array must be observed.