### PR TITLE
Make optionIdPath configurable.

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -32,6 +32,7 @@ var Select2Component = Ember.Component.extend({
   // Bindings that may be overwritten in the template
   inputSize: "input-md",
   cssClass: null,
+  optionIdPath: "id",
   optionValuePath: null,
   optionLabelPath: 'text',
   optionHeadlinePath: 'text',
@@ -57,6 +58,7 @@ var Select2Component = Ember.Component.extend({
   didInsertElement: function() {
     var self = this,
         options = {},
+        optionIdPath = this.get('optionIdPath'),
         optionLabelPath = this.get('optionLabelPath'),
         optionHeadlinePath = this.get('optionHeadlinePath'),
         optionDescriptionPath = this.get('optionDescriptionPath'),
@@ -71,10 +73,10 @@ var Select2Component = Ember.Component.extend({
     options.multiple = this.get('multiple');
     options.allowClear = this.get('allowClear');
     options.minimumResultsForSearch = this.get('searchEnabled') ? 0 : -1 ;
-    
+
     // override select2's default id fetching behavior
     options.id = (function(e) {
-      return (e === undefined) ? null : get(e, 'id');
+      return (e === undefined) ? null : get(e, optionIdPath);
     });
 
     // allowClear is only allowed with placeholder
@@ -98,7 +100,7 @@ var Select2Component = Ember.Component.extend({
       }
 
       var output,
-          id = get(item, "id"),
+          id = get(item, optionIdPath),
           text = get(item, optionLabelPath),
           headline = get(item, optionHeadlinePath),
           description = get(item, optionDescriptionPath);


### PR DESCRIPTION
This allows you to work with objects who have a unique identifier at an attribute other than 'id'.

Our specific use case is we have a constant drop down of countries, whose ID is their three digit ISO code, available at the attribute of "abbreviation". These are plain old JavaScript objects inside an `Ember.A`. Since the unique attribute is "abbreviation", Select2 broke. Now that it's configurable, it works perfectly fine.