### PR TITLE
Add min length and did select action on selection changed

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -71,7 +71,7 @@ var Select2Component = Ember.Component.extend({
     options.multiple = this.get('multiple');
     options.allowClear = this.get('allowClear');
     options.minimumResultsForSearch = this.get('searchEnabled') ? 0 : -1 ;
-    
+
     options.minimumInputLength = this.get('minimumInputLength');
 
     // override select2's default id fetching behavior
@@ -427,6 +427,7 @@ var Select2Component = Ember.Component.extend({
     }
 
     this.set("value", value);
+    this.sendAction('didSelect');
   },
 
   /**

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -72,6 +72,8 @@ var Select2Component = Ember.Component.extend({
     options.allowClear = this.get('allowClear');
     options.minimumResultsForSearch = this.get('searchEnabled') ? 0 : -1 ;
     
+    options.minimumInputLength = this.get('minimumInputLength');
+
     // override select2's default id fetching behavior
     options.id = (function(e) {
       return (e === undefined) ? null : get(e, 'id');

--- a/tests/unit/components/select-2-test.js
+++ b/tests/unit/components/select-2-test.js
@@ -127,6 +127,32 @@ test("it sets value to selected object in single selection mode", function() {
   });
 });
 
+test("it sends `didSelect` action once when selection has been changed", function() {
+  expect(1);
+
+  var controller = {
+    selectionChanged: function() {}
+  };
+  var spy = sinon.spy(controller, 'selectionChanged');
+
+  component.setProperties({
+    targetObject: controller,
+    content: simpleContent,
+    didSelect: 'selectionChanged'
+  });
+
+  this.append();
+
+  // open options by clicking on the element
+  click('.select2-choice');
+  // then select an option
+  click('.select2-results li:nth-child(3)', 'body');
+
+  andThen(function() {
+    ok(spy.calledOnce, "callback after selection changed has been executed");
+  });
+});
+
 test("it supports the allowClear option", function() {
   expect(3);
 

--- a/tests/unit/components/select-2-typeahead-test.js
+++ b/tests/unit/components/select-2-typeahead-test.js
@@ -123,6 +123,20 @@ test("it displays options from ArrayProxy", function() {
   });
 });
 
+test("it displays default minimum text", function() {
+  expect(1);
+
+  component.set("minimumInputLength", 3);
+
+  this.append();
+
+  // open options by clicking on the element
+  click('.select2-choice');
+
+  andThen(function() {
+    equal($('li.select2-no-results').text(), "Please enter 3 or more characters", "displays minimum text info");
+  });
+});
 
 test("it displays default searching text when waiting for results for first time", function() {
   expect(1);


### PR DESCRIPTION
This pull request adds two features:
* adds minimium length as in [this pull request](https://github.com/iStefo/ember-select-2/pull/55), but moreover provides tests for this feature
* adds sending action `didSelect` on selection changing and provides tests for this feature

I bumped into case when `didSelect` was useful to take care of auto-save after selection change in model relationships. Using value observer I got it executed twice and due to fact that the reletionships are not changing `model.isDirty` flag I couldn't find a clean solution. `didSelect` provides that one.