### PR TITLE
Make the inclusion of Select2's CSS and image assets optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,19 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
- 
+
+    var config = this.project.config(app.env);
+    var includeSelect2Assets = (
+      config.includeSelect2Assets === undefined || config.includeSelect2Assets
+    );
+
     app.import(app.bowerDirectory + '/select2/select2.js');
-    app.import(app.bowerDirectory + '/select2/select2.css');
-    app.import(app.bowerDirectory + '/select2/select2.png', { destDir: 'assets' });
-    app.import(app.bowerDirectory + '/select2/select2x2.png', { destDir: 'assets' });
-    app.import(app.bowerDirectory + '/select2/select2-spinner.gif', { destDir: 'assets' });
+
+    if (includeSelect2Assets) {
+      app.import(app.bowerDirectory + '/select2/select2.css');
+      app.import(app.bowerDirectory + '/select2/select2.png', { destDir: 'assets' });
+      app.import(app.bowerDirectory + '/select2/select2x2.png', { destDir: 'assets' });
+      app.import(app.bowerDirectory + '/select2/select2-spinner.gif', { destDir: 'assets' });
+    }
   }
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function(environment) {
     environment: environment,
     contentSecurityPolicyHeader: 'Disabled-Content-Security-Policy',
     baseURL: '/',
+    includeSelect2Assets: true,
     locationType: 'auto',
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
Based on an EmberENV configuration key's value, decide whether or not we should include Select2's own CSS and images in the compiled output.

The default (if the key doesn't exist) is to maintain the current behaviour and include the assets.

Applications can opt in/out of the asset's inclusion in their environment's config:

```javascript
module.exports = function(environment) {
  var ENV = {
    modulePrefix: 'dummy',
    environment: environment,
    contentSecurityPolicyHeader: 'Disabled-Content-Security-Policy',
    baseURL: '/',
    includeSelect2Assets: true,
    locationType: 'auto',
    EmberENV: {
      FEATURES: {
        // Here you can enable experimental features on an ember canary build
        // e.g. 'with-controller': true
      }
    },
    version: require('../../../package').version,

    APP: {
      // Here you can pass flags/options to your application instance
      // when it is created
    }
  };
// ...
```