### PR TITLE
The `didSelect` action should wait for databinding

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -432,7 +432,9 @@ var Select2Component = Ember.Component.extend({
     }
 
     this.set("value", value);
-    this.sendAction('didSelect');
+    Ember.run.schedule('actions', this, function() {
+      this.sendAction('didSelect');
+    });
   },
 
   /**


### PR DESCRIPTION
The `didSelect` action is triggered before the value was set. It is currently not possible to get the selected value at the action time.

The action should be triggered in the `action` run loop to wait for data binding.

Sorry for the lack of tests. I'm not really at ease with they to create it.