### PR TITLE
Fix for Ember BINDING STYLE ATTRIBUTES Warning

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -27,7 +27,7 @@ var Select2Component = Ember.Component.extend({
   classNames: ["form-control"],
   classNameBindings: ["inputSize"],
   attributeBindings: ["style"],
-  style: "display: hidden;",
+  style: Ember.Handlebars.SafeString("display: hidden;"),
 
   // Bindings that may be overwritten in the template
   inputSize: "input-md",


### PR DESCRIPTION
Fix for Ember BINDING STYLE ATTRIBUTES Warning
Doc: http://emberjs.com/deprecations/v1.x/#toc_warning-when-binding-style-attributes