### PR TITLE
Allow different value separators

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -286,8 +286,15 @@ var Select2Component = Ember.Component.extend({
         !self.get('_typeaheadMode'));
 
 
-      var values = value.split(","),
-          filteredContent = [];
+      var values;
+      var filteredContent = [];
+
+      if (self.get('skipValueSeparator')) {
+        values = [value];
+      } else {
+        var separator = self.get('valueSeparator') || ",";
+        values = value.split(separator);
+      }
 
       // for every object, check if its optionValuePath is in the selected
       // values array and save it to the right position in filteredContent

--- a/tests/unit/components/select-2-test.js
+++ b/tests/unit/components/select-2-test.js
@@ -470,6 +470,54 @@ test("it is disabled when its selection contains values not in the content array
   ok(!$('.select2-container').hasClass('select2-container-disabled'), "is enabled");
 });
 
+test("it allows disabling the separator for values", function() {
+  expect(1);
+
+  this.append();
+
+  var content = [
+    {
+      id: "Normal",
+      text: "Normal",
+    },
+    {
+      id: "Multiple, Things",
+      text: "Multiple, Things",
+    }
+  ];
+
+  component.set('skipValueSeparator', true);
+  component.set('content', content);
+  component.set('optionValuePath', 'id');
+  component.set('value', "Multiple, Things");
+
+  ok(!component.get('_hasSelectedMissingItems'), "items are missing");
+});
+
+test("it allows using a custom separator for values", function() {
+  expect(1);
+
+  this.append();
+
+  var content = [
+    {
+      id: "First",
+      text: "First",
+    },
+    {
+      id: "Second",
+      text: "Second",
+    }
+  ];
+
+  component.set('valueSeparator', "|");
+  component.set('content', content);
+  component.set('optionValuePath', 'id');
+  component.set('value', "First|Second");
+
+  ok(!component.get('_hasSelectedMissingItems'), "items are missing");
+});
+
 test("Change event does not trigger an autorun", function() {
   expect(1);
 


### PR DESCRIPTION
First of all, thank you for your work on this plugin. It saved me a huge amount of time vs wrapping select2 myself!

I ran into an issue with my "values" having a comma in them. If a user selected any value with a comma in it, the select box would be disabled because it couldn't find the value in the content array. To take care of this issue I've made two changes:

1. Allow the users to use a custom value separator. In case they ever want to split on something else.
2. Allow the users to disable value separation all together. My opinion would probably be to not offer value splitting by default or to allow `valueSeparator=null` to override the default but I couldn't find anyway to support the single property option without a breaking change and I would love to get this feature in ASAP. The way it is written now, unless I missed something, you should be able to release this without a major version bump.

I'm happy to make any test changes you'd prefer, this way seemed to be the most obvious way of testing it but I'm happy to accept any feedback.