### PR TITLE
ember-cli 0.2.7 upgrade

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 bower_components/
 tests/
 tmp/
+dist/
 
 .bowerrc
 .editorconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,19 @@ cache:
   directories:
     - node_modules
 
+env:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -19,4 +31,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp"]
+}

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,20 +3,15 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+/*
+  This Brocfile specifes the options for the dummy test app of this
+  addon, located in `/tests/dummy`
 
-// Use `app.import` to add additional libraries to the generated
-// output files.
-//
-// If you need to use different assets in different
-// environments, specify an object as the first parameter. That
-// object's keys should be the environment name and the values
-// should be the asset to use in that environment.
-//
-// If the library that you are including contains AMD or ES6
-// modules that you would like to import into your application
-// please specify an object with the list of modules as keys
-// along with the exports of each module as its value.
+  This Brocfile does *not* influence how the addon or the app using it
+  behave. You most likely want to be modifying `./index.js` or app's Brocfile
+*/
+
+var app = new EmberAddon();
 
 // dependency for the highlight-code component
 app.import('bower_components/highlightjs/highlight.pack.js');

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,9 +17,6 @@ var app = new EmberAddon();
 app.import('bower_components/highlightjs/highlight.pack.js');
 app.import('bower_components/boxuk/index.css');
 
-// load sinon for test spies
-app.import('bower_components/sinon/index.js');
-
 // this is just to override the default select2 css to look better with bootstrap
 app.import('bower_components/bootstrap/dist/css/bootstrap.css');
 app.import('bower_components/select2-bootstrap/select2-bootstrap.css');

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright (c) 2015
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "boxuk": "https://raw.githubusercontent.com/daylerees/colour-schemes/master/highlightjs/boxuk.css",
-    "sinon": "http://sinonjs.org/releases/sinon-1.12.1.js"
+    "sinonjs": "~1.14.1"
   },
   "devDependencies": {
     "select2": "~3.5.1",

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-select-2",
   "dependencies": {
-    "ember": "1.11.1",
+    "ember": "1.12.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.16.1",
+    "ember-data": "1.0.0-beta.18",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.1",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,35 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.3",
+    "ember-cli": "0.2.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.10",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.16.1",
+    "ember-cli-qunit": "0.3.13",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-data": "1.0.0-beta.18",
     "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.4"
+    "ember-try": "0.0.6"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-sinon": "0.2.1",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,8 +21,7 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName",
-    "sinon"
+    "currentRouteName"
   ],
   "node": false,
   "browser": false,

--- a/tests/dummy/app/templates/components/highlight-code.hbs
+++ b/tests/dummy/app/templates/components/highlight-code.hbs
@@ -1,1 +1,1 @@
-<code {{bind-attr class=languageClass}}>{{yield}}</code>
+<code class="{{languageClass}}">{{yield}}</code>

--- a/tests/dummy/public/crossdomain.xml
+++ b/tests/dummy/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>

--- a/tests/dummy/public/robots.txt
+++ b/tests/dummy/public/robots.txt
@@ -1,2 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
+Disallow:

--- a/tests/unit/components/select-2-test.js
+++ b/tests/unit/components/select-2-test.js
@@ -5,6 +5,7 @@
 import Ember from "ember";
 import { test, moduleFor, moduleForComponent } from 'ember-qunit';
 import startApp from "../../helpers/start-app";
+import sinon from "sinon";
 
 /*
   Test Fixtures

--- a/tests/unit/components/select-2-typeahead-test.js
+++ b/tests/unit/components/select-2-typeahead-test.js
@@ -10,7 +10,7 @@
 import Ember from "ember";
 import { test, moduleFor, moduleForComponent } from 'ember-qunit';
 import startApp from "../../helpers/start-app";
-
+import sinon from "sinon";
 
 var simpleContent = Ember.A([
   {
@@ -378,7 +378,7 @@ test("it displays custom `typeaheadNoMatchesText` text", function(assert) {
 
   fillIn('.select2-input', 'body', 'bla');
 
-  andThen(function() {    
+  andThen(function() {
     assert.equal($('li.select2-no-results').text(), "No results for ", "display custom no results text");
   });
 });


### PR DESCRIPTION
Also, a replacement for the global `sinon` package (replaced with [ember-sinon](https://github.com/csantero/ember-sinon)) and deprecation squashing.