### PR TITLE
Enable all select2 api options

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -88,7 +88,7 @@ var Select2Component = Ember.Component.extend({
     
     // ensures that max selection size is numeric or null.
     var maximumSelectionSizeValueIsValid = (typeof this.get('maximumSelectionSize') === 'number' || typeof this.get('maximumSelectionSize') === null);
-    Ember.assert("select2 maximumSelectionSize value must be numeric", maximumSelectionSizeValueIsValid);    
+    Ember.assert("select2 maximumSelectionSize value must be numeric or null", maximumSelectionSizeValueIsValid);    
     
     // ensure there is a value separator if needed (= when in multiple selection with value binding)
     var missesValueSeperator = this.get('multiple') && this.get('optionValuePath') && !this.get('valueSeparator');

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -84,7 +84,11 @@ var Select2Component = Ember.Component.extend({
     options.minimumInputLength = this.get('minimumInputLength');
     options.maximumInputLength = this.get('maximumInputLength');
     options.maximumSelectionSize = this.get('maximumSelectionSize');
-    options.closeOnSelect = this.get('closeOnSelect');
+    options.closeOnSelect = !!this.get('closeOnSelect'); // !! ensures bool value.
+    
+    // ensures that max selection size is numeric or null.
+    var maximumSelectionSizeValueIsValid = (typeof this.get('maximumSelectionSize') === 'number' || typeof this.get('maximumSelectionSize') === null);
+    Ember.assert("select2 maximumSelectionSize value must be numeric", maximumSelectionSizeValueIsValid);    
     
     // ensure there is a value separator if needed (= when in multiple selection with value binding)
     var missesValueSeperator = this.get('multiple') && this.get('optionValuePath') && !this.get('valueSeparator');

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -51,7 +51,9 @@ var Select2Component = Ember.Component.extend({
   minimumInputLength: null,
   maximumInputLength: null,
   valueSeparator: ',',
-
+  maximumSelectionSize: null,
+  closeOnSelect: true,
+  
   // internal state
   _hasSelectedMissingItems: false,
   _hasPendingContentPromise: Ember.computed.alias('content.isPending'),
@@ -81,7 +83,9 @@ var Select2Component = Ember.Component.extend({
     options.minimumResultsForSearch = this.get('searchEnabled') ? 0 : -1 ;
     options.minimumInputLength = this.get('minimumInputLength');
     options.maximumInputLength = this.get('maximumInputLength');
-
+    options.maximumSelectionSize = this.get('maximumSelectionSize');
+    options.closeOnSelect = this.get('closeOnSelect');
+    
     // ensure there is a value separator if needed (= when in multiple selection with value binding)
     var missesValueSeperator = this.get('multiple') && this.get('optionValuePath') && !this.get('valueSeparator');
     Ember.assert("select2#didInsertElement: You must specify a valueSeparator when in multiple mode.", !missesValueSeperator);

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -51,9 +51,56 @@ var Select2Component = Ember.Component.extend({
   minimumInputLength: null,
   maximumInputLength: null,
   valueSeparator: ',',
-  maximumSelectionSize: null,
-  closeOnSelect: true,
-  
+
+  select2api: [
+    'width',
+    'minimumInputLength',
+    'maximumInputLength',
+    'minimumResultsForSearch',
+    'maximumSelectionSize',
+    'placeholder',
+    'placeholderOption',
+    'separator',
+    'allowClear',
+    'multiple',
+    'closeOnSelect',
+    'openOnEnter',
+    'id',
+    'matcher',
+    'sortResults',
+    'formatSelection',
+    'formatResult',
+    'formatResultCssClass',
+    'formatNoMatches',
+    'formatSearching',
+    'formatAjaxError',
+    'formatInputTooShort',
+    'formatInputTooLong',
+    'formatSelectionTooBig',
+    'formatLoadMore',
+    'createSearchChoice',
+    'createSearchChoicePosition',
+    'initSelection',
+    'tokenizer',
+    'tokenSeparators',
+    'query',
+    'ajax',
+    'data',
+    'tags',
+    'containerCss',
+    'containerCssClass',
+    'dropdownCss',
+    'dropdownCssClass',
+    'dropdownAutoWidth',
+    'adaptContainerCssClass',
+    'adaptDropdownCssClass',
+    'escapeMarkup',
+    'selectOnBlur',
+    'loadMorePadding',
+    'nextSearchTerm'
+  ],
+
+
   // internal state
   _hasSelectedMissingItems: false,
   _hasPendingContentPromise: Ember.computed.alias('content.isPending'),
@@ -76,30 +123,36 @@ var Select2Component = Ember.Component.extend({
     // ensure select2 is loaded
     Ember.assert("select2 has to exist on Ember.$.fn.select2", typeof Ember.$.fn.select2 === "function");
 
-    // setup
-    options.placeholder = this.get('placeholder');
-    options.multiple = this.get('multiple');
-    options.allowClear = this.get('allowClear');
     options.minimumResultsForSearch = this.get('searchEnabled') ? 0 : -1 ;
-    options.minimumInputLength = this.get('minimumInputLength');
-    options.maximumInputLength = this.get('maximumInputLength');
-    options.maximumSelectionSize = this.get('maximumSelectionSize');
-    options.closeOnSelect = !!this.get('closeOnSelect');
-    
-    // ensures that max selection size is numeric or null.
-    var maximumSelectionSizeValueIsValid = (!isNaN(this.get('maximumSelectionSize')) || this.get('maximumSelectionSize') === null);
-    Ember.assert("select2 maximumSelectionSize value must be numeric or null", maximumSelectionSizeValueIsValid);    
-    
-    // ensure there is a value separator if needed (= when in multiple selection with value binding)
-    var missesValueSeperator = this.get('multiple') && this.get('optionValuePath') && !this.get('valueSeparator');
-    Ember.assert("select2#didInsertElement: You must specify a valueSeparator when in multiple mode.", !missesValueSeperator);
-
     options.separator = this.get('valueSeparator');
+
+    /*
+      Can define an options hash on the controller implimenting this compoennet
+      then assign that hash to `optionsHash` property on the compoennet.
+      need to know
+    */
+    var useOptionsHash = !!this.get('optionsHash');
+
+    /*
+      if user defined a valid option from the select2api, assign it in the options obj
+    */
+    var value;
+    this.get('select2api').forEach((option) => {
+      value = useOptionsHash ? this.get('optionsHash')[option] : this.get(option);
+      if (value !== undefined) {
+        options[option] = value;
+      }
+    });
+
 
     // override select2's default id fetching behavior
     options.id = (function(e) {
       return (e === undefined) ? null : get(e, optionIdPath);
     });
+
+    // ensure there is a value separator if needed (= when in multiple selection with value binding)
+    var missesValueSeperator = this.get('multiple') && this.get('optionValuePath') && !this.get('valueSeparator');
+    Ember.assert("select2#didInsertElement: You must specify a valueSeparator when in multiple mode.", !missesValueSeperator);
 
     // allowClear is only allowed with placeholder
     Ember.assert("To use allowClear, you have to specify a placeholder", !options.allowClear || options.placeholder);

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -127,23 +127,13 @@ var Select2Component = Ember.Component.extend({
     options.separator = this.get('valueSeparator');
 
     /*
-      Can define an options hash on the controller implimenting this compoennet
-      then assign that hash to `optionsHash` property on the compoennet.
-      need to know
-    */
-    var useOptionsHash = !!this.get('optionsHash');
-
-    /*
       if user defined a valid option from the select2api, assign it in the options obj
     */
-    var value;
     this.get('select2api').forEach((option) => {
-      value = useOptionsHash ? this.get('optionsHash')[option] : this.get(option);
-      if (value !== undefined) {
-        options[option] = value;
+      if (this.get(option) !== undefined) {
+        options[option] = this.get(option);
       }
     });
-
 
     // override select2's default id fetching behavior
     options.id = (function(e) {

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -84,10 +84,10 @@ var Select2Component = Ember.Component.extend({
     options.minimumInputLength = this.get('minimumInputLength');
     options.maximumInputLength = this.get('maximumInputLength');
     options.maximumSelectionSize = this.get('maximumSelectionSize');
-    options.closeOnSelect = !!this.get('closeOnSelect'); // !! ensures bool value.
+    options.closeOnSelect = !!this.get('closeOnSelect');
     
     // ensures that max selection size is numeric or null.
-    var maximumSelectionSizeValueIsValid = (typeof this.get('maximumSelectionSize') === 'number' || typeof this.get('maximumSelectionSize') === null);
+    var maximumSelectionSizeValueIsValid = (!isNaN(this.get('maximumSelectionSize')) || this.get('maximumSelectionSize') === null);
     Ember.assert("select2 maximumSelectionSize value must be numeric or null", maximumSelectionSizeValueIsValid);    
     
     // ensure there is a value separator if needed (= when in multiple selection with value binding)

--- a/tests/unit/components/select-2-customize-test.js
+++ b/tests/unit/components/select-2-customize-test.js
@@ -80,6 +80,7 @@ moduleForComponent('select-2', 'Select2Component (customize)', {
 });
 
 
+
 test("it uses optionLabelPath", function(assert) {
   assert.expect(2);
 
@@ -277,6 +278,51 @@ test("uses `valueSeparator`", function(assert) {
   });
 });
 
+test("it uses maximumSelectionValue", function(assert){
+
+  assert.expect(2);
+
+  component.setProperties({
+    content: [
+      {
+        id: "first",
+        text: "First",
+      }, {
+        id: "second",
+        text: "Second",
+      }, {
+        id: "third",
+        text: "Third"
+      }
+    ],
+    multiple: true,
+    optionValuePath: 'id',
+    maximumSelectionSize: '2'
+  });
+ 
+  this.render();
+
+   // open options by clicking on the element
+  click('.select2-choices');
+  // then select an option
+  click('.select2-results li:nth-child(1)', 'body');
+
+  // open options by clicking on the element
+  click('.select2-choices');
+
+  andThen(function(){
+    assert.strictEqual($('.select2-selection-limit').length, 0, "allows adding more before limit is reached");
+  });
+
+  // and select another option
+  click('.select2-results li:nth-child(2)', 'body');
+
+  click('.select2-choices');
+  
+  andThen(function(){
+    assert.strictEqual($('.select2-selection-limit').length, 1, "prevents adding more when limit is reached");
+  });
+});
 
 test("uses `optionLabelSelectedPath`", function(assert) {
   assert.expect(1);


### PR DESCRIPTION
Hey @iStefo, thanks for making this addon. you did a great job on it. 

I understand you have limited time to work on this project, so i hope this is helpful. I added a comprehensive  list of available select2 api options to pass when initializing select-2  v3.5.2 which will loop over and see if a user has defined the option, and if so it will include it in the initialization options. 

I didn't bother cross-referencing what options can be used with which other options because i think that should be an issue handled by select-2, no?
