### PR TITLE
Fixed issue when allowClear didn't set the value to null

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -466,6 +466,11 @@ var Select2Component = Ember.Component.extend({
     } else {
       value = data;
     }
+    
+    //Ensure value is set to null if its empty or undefined
+    if (Ember.isEmpty(value)) {
+      value = null;
+    }
 
     this.set("value", value);
     Ember.run.schedule('actions', this, function() {


### PR DESCRIPTION
When clicking the clear button the Ember value wasn't set to null. I think this only happened when an optionValuePath was set. This fixes #112
