### PR TITLE
Fix fmt deprecation for ember 2 +

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -246,7 +246,7 @@ var Select2Component = Ember.Component.extend({
 
       term = Ember.Handlebars.Utils.escapeExpression(term);
 
-      return Ember.String.htmlSafe(Ember.String.fmt(text, term));
+      return Ember.String.htmlSafe(text.replace('%@', term));
     };
 
     /*
@@ -256,7 +256,7 @@ var Select2Component = Ember.Component.extend({
     options.formatAjaxError = function(jqXHR, textStatus, errorThrown) {
       var text = self.get('typeaheadErrorText');
 
-      return Ember.String.htmlSafe(Ember.String.fmt(text, errorThrown));
+      return Ember.String.htmlSafe(text.replace('%@', errorThrown));
     };
 
     /*


### PR DESCRIPTION
Just replaced `Ember.string.fmt()` with a simple `.replace()` since only one argument is guaranteed to be present.  

References issue #124 
