### PR TITLE
Check presence of value object on `selectionChanged` with `optionValuePath` specified

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -455,7 +455,7 @@ var Select2Component = Ember.Component.extend({
 
     // if there is a optionValuePath, don't set value to the complete object,
     // but only the property referred to by optionValuePath
-    if (optionValuePath) {
+    if (optionValuePath && !Ember.isNone(data)) {
       if (multiple) {
         // data is an array, so use getEach
         value = Ember.A(data).getEach(optionValuePath);


### PR DESCRIPTION
There is a case when we need to clear value in the component via `x` button when we have `allowClear=true` specified. Component should not try to get value from `optionValuePath` property of a null value.
